### PR TITLE
Update Karabiner-DriverKit-VirtualHIDDevice to 1.22.0

### DIFF
--- a/c_src/mac/keyio_mac.hpp
+++ b/c_src/mac/keyio_mac.hpp
@@ -5,6 +5,7 @@
 #include <thread>
 #include <map>
 #include <iostream>
+#include <filesystem>
 #include <mach/mach_error.h>
 
 int init_sink(void);

--- a/keymap/user/Rougemoot/applekeeb.kbd
+++ b/keymap/user/Rougemoot/applekeeb.kbd
@@ -88,7 +88,7 @@ allow-cmd true
 				@fn  _    _    _              @spc      bspc _    _    _    _    _
 )
 
-(defalias fn (around (layer-toggle functin) fn))	
+(defalias fn (around (layer-toggle function) fn))	
 (deflayer function
         _    f1   f2   f3   f4   f5   f6   f7   f8   f9   f10  f11  f12
              _    _    _    _    _    _    _    _    _    _    _    _    _


### PR DESCRIPTION

The present release version of Karabiner Element (13.4.0) ships with a dext version of 1.22.0, and kmonad should keep up with that. This relates to issue #67, and specifically a thread started around [here](https://github.com/david-janssen/kmonad/issues/67#issuecomment-814256141).